### PR TITLE
Fix damages bug j2->j1 + update TestBugDegats

### DIFF
--- a/src/boundary/BoundaryJeu.java
+++ b/src/boundary/BoundaryJeu.java
@@ -178,6 +178,7 @@ public class BoundaryJeu {
 			
 			// Passer au joueur suivant
 			tourJoueur++;
+			controlJeu.passerAuJoueurSuivant();
 			
 			// Si ce n'est pas la fin de partie, demander si on continue l'itération
 			if (!finPartie && (tourJoueur % 2 == 0)) { // À chaque fin d'itération (après que les deux joueurs ont joué)

--- a/src/ressources/pirates/AnneBonny.txt
+++ b/src/ressources/pirates/AnneBonny.txt
@@ -2,3 +2,4 @@
 popularite: 0
 vie: 6
 image: src/ressources/image_pirate/AnneBonny.jpg
+carte: src/ressources/cartes/strategique/popularite/popularite1.txt

--- a/src/test/TestBugDegatsJ2versJ1.java
+++ b/src/test/TestBugDegatsJ2versJ1.java
@@ -1,13 +1,16 @@
 package test;
 
-/*
+
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
+import carte.CarteAttaque;
 import carte.CarteOffensive;
 import controllers.ControlCartePlateau;
 import controllers.ControlJeu;
+import controllers.ControlJoueur;
 import joueur.Joueur;
+import joueur.Pirate;
 
 public class TestBugDegatsJ2versJ1 {
 
@@ -15,8 +18,16 @@ public class TestBugDegatsJ2versJ1 {
     public void testAttaqueJ2versJ1() {
         // Initialisation
         ControlJeu controlJeu = new ControlJeu();
-        Joueur joueur1 = controlJeu.creerJoueur("Joueur1", "Jack Sparrow");
-        Joueur joueur2 = controlJeu.creerJoueur("Joueur2", "Barbe Noire");
+        Pirate pirate1 = new Pirate("AnneBonny");
+        Pirate pirate2 = new Pirate("BarbeNoire");
+        
+        controlJeu.initialiserJeu(pirate1, pirate2);
+        
+        ControlJoueur controlJoueur1 = controlJeu.getJoueur(0);
+        ControlJoueur controlJoueur2 = controlJeu.getJoueur(1);
+        
+        Joueur joueur1 = controlJoueur1.getJoueur();
+        Joueur joueur2 = controlJoueur2.getJoueur();
         
         // Points de vie initiaux
         joueur1.setVie(5);
@@ -25,12 +36,16 @@ public class TestBugDegatsJ2versJ1 {
         ControlCartePlateau cCartePlateau = controlJeu.getControlCartePlateau();
         
         // Carte d'attaque du joueur 2
-        CarteOffensive attaqueJ2 = new CarteOffensive("Canon", "Un puissant canon", 2, 0, 
-                                                     CarteOffensive.TypeOffensif.ATTAQUE);
-        cCartePlateau.ajouterCarteOffensiveJ2(attaqueJ2);
+        CarteOffensive attaqueJ2 = new CarteAttaque("Canon", "Un puissant canon", 2, 2, 0);
+        
+        //ajout des cartes à la mains des joueurs, sinon jouerCarte renvoie false et ne place pas la carte dans la zoneOffensive
+        controlJoueur2.getJoueur().ajouterCarte(attaqueJ2);
+        
+        controlJoueur2.jouerCarte(attaqueJ2);
+
         
         // Application des effets
-        cCartePlateau.appliquerEffetsCartesOffensives();
+        cCartePlateau.appliquerEffetCarte();
         
         // Vérifications
         assertEquals(3, joueur1.getPointsDeVie(), "Le joueur 1 devrait avoir perdu 2 points de vie");
@@ -40,9 +55,17 @@ public class TestBugDegatsJ2versJ1 {
     @Test
     public void testPartieComplete() {
         // Initialisation
-        ControlJeu controlJeu = new ControlJeu();
-        Joueur joueur1 = controlJeu.creerJoueur("Joueur1", "Jack Sparrow");
-        Joueur joueur2 = controlJeu.creerJoueur("Joueur2", "Barbe Noire");
+    	ControlJeu controlJeu = new ControlJeu();
+        Pirate pirate1 = new Pirate("AnneBonny");
+        Pirate pirate2 = new Pirate("BarbeNoire");
+         
+        controlJeu.initialiserJeu(pirate1, pirate2);
+         
+        ControlJoueur controlJoueur1 = controlJeu.getJoueur(0);
+        ControlJoueur controlJoueur2 = controlJeu.getJoueur(1);
+         
+        Joueur joueur1 = controlJoueur1.getJoueur();
+        Joueur joueur2 = controlJoueur2.getJoueur();
         
         joueur1.setVie(5);
         joueur2.setVie(5);
@@ -50,15 +73,21 @@ public class TestBugDegatsJ2versJ1 {
         ControlCartePlateau cCartePlateau = controlJeu.getControlCartePlateau();
         
         // Tour 1: attaques des deux côtés
-        CarteOffensive attaqueJ1 = new CarteOffensive("Sabre", "Un sabre tranchant", 1, 0, 
-                                                    CarteOffensive.TypeOffensif.ATTAQUE);
-        CarteOffensive attaqueJ2 = new CarteOffensive("Pistolet", "Un pistolet précis", 2, 0, 
-                                                    CarteOffensive.TypeOffensif.ATTAQUE);
+        CarteOffensive attaqueJ1 = new CarteAttaque("Sabre", "Un sabre tranchant", 2, 1, 0);
+        CarteOffensive attaqueJ2 = new CarteAttaque("Pistolet", "Un pistolet précis", 2, 2, 0);
         
-        cCartePlateau.ajouterCarteOffensiveJ1(attaqueJ1);
-        cCartePlateau.ajouterCarteOffensiveJ2(attaqueJ2);
+        //ajout des cartes à la mains des joueurs, sinon jouerCarte renvoie false et ne place pas la carte dans la zoneOffensive
+        controlJoueur1.getJoueur().ajouterCarte(attaqueJ1);
+        controlJoueur2.getJoueur().ajouterCarte(attaqueJ2);
         
-        cCartePlateau.appliquerEffetsCartesOffensives();
+    	controlJoueur1.jouerCarte(attaqueJ1);
+    	controlJoueur2.jouerCarte(attaqueJ2);
+    	
+    	assertEquals(false, cCartePlateau.getZoneJoueur1().getZoneOffensive().getCartesOffensives().isEmpty(), "Le joueur 1 a une zone de carte offensive vide");
+    	assertEquals(false, cCartePlateau.getZoneJoueur2().getZoneOffensive().getCartesOffensives().isEmpty(), "Le joueur 2 a une zone de carte offensive vide");
+
+        
+        cCartePlateau.appliquerEffetCarte();
         
         // Vérifications après tour 1
         assertEquals(3, joueur1.getPointsDeVie(), "Le joueur 1 devrait avoir 3 points de vie après le tour 1");
@@ -68,14 +97,18 @@ public class TestBugDegatsJ2versJ1 {
         cCartePlateau.defausserCartesPlateau();
         
         // Tour 2: attaque du joueur 2 uniquement
-        CarteOffensive attaqueJ2Tour2 = new CarteOffensive("Canon", "Un puissant canon", 3, 0, 
-                                                         CarteOffensive.TypeOffensif.ATTAQUE);
-        cCartePlateau.ajouterCarteOffensiveJ2(attaqueJ2Tour2);
+        CarteOffensive attaqueJ2Tour2 = new CarteAttaque("Canon", "Un puissant canon", 2, 3, 0);
         
-        cCartePlateau.appliquerEffetsCartesOffensives();
+        //ajout des cartes à la mains des joueurs, sinon jouerCarte renvoie false et ne place pas la carte dans la zoneOffensive
+        controlJoueur2.getJoueur().ajouterCarte(attaqueJ2Tour2);
+        
+        controlJoueur2.jouerCarte(attaqueJ2Tour2);
+        
+        
+        cCartePlateau.appliquerEffetCarte();
         
         // Vérifications après tour 2
         assertEquals(0, joueur1.getPointsDeVie(), "Le joueur 1 devrait avoir 0 points de vie après le tour 2");
         assertEquals(4, joueur2.getPointsDeVie(), "Le joueur 2 devrait toujours avoir 4 points de vie après le tour 2");
     }
-}*/
+}


### PR DESCRIPTION
Dans BoundaryJeu::jouerPartie() on n'appelait jamais controlJeu.passerAuJoueurSuivant(). Donc les cartes jouées par j2 n'étaient pas mises dans sa zone offensive, car controlJeu.jouerCarte() dépend de JoeurActif.

Par contre je ne sais comment le joueur2 pouvait "jouer" (la boundary jouait sont tour) et pourquoi les cartes n'étaient pas placés dans la zoneOffensive du joueur1.

+update de TestBugDégatsJ2versJ1 suivant la nouvelle logique

+rajout d'une carte spécial pour AnneBonny (popularite1)