### PR TITLE
Fix 3 tours max BoundaryJeu

### DIFF
--- a/src/boundary/BoundaryJeu.java
+++ b/src/boundary/BoundaryJeu.java
@@ -10,6 +10,7 @@ import carte.CarteStrategique;
 import controllers.ControlJeu;
 import controllers.ControlJoueur;
 import controllers.ControlMarche;
+import controllers.ControlPioche;
 import joueur.Joueur;
 import joueur.Pirate;
 import joueur.ParserPirate;
@@ -170,8 +171,11 @@ public class BoundaryJeu {
 			// Appliquer les effets des cartes sur le plateau
 			controlJeu.appliquerEffetsCartes();
 			
+			
+			
 			// Vérifier si la partie est terminée
 			finPartie = controlJeu.verifierFinPartie();
+			
 			
 			// Défausser les cartes du plateau à la fin du tour
 			controlJeu.defausserCartesPlateau();
@@ -179,6 +183,9 @@ public class BoundaryJeu {
 			// Passer au joueur suivant
 			tourJoueur++;
 			controlJeu.passerAuJoueurSuivant();
+			
+			// Remplir la pioche si elle est vide
+			controlJeu.verifierPiocheNonVide();
 			
 			// Si ce n'est pas la fin de partie, demander si on continue l'itération
 			if (!finPartie && (tourJoueur % 2 == 0)) { // À chaque fin d'itération (après que les deux joueurs ont joué)

--- a/src/boundary/BoundaryJeu.java
+++ b/src/boundary/BoundaryJeu.java
@@ -132,8 +132,12 @@ public class BoundaryJeu {
 		boolean finPartie = false;
 		int tourJoueur = 0;
 		boolean continuerIteration = true;
+		int nbTour = 0;
+		int nbToursMax = 20;
 		
 		while (!finPartie && continuerIteration) {
+			nbTour++;
+			
 			// Déterminer le joueur actif
 			ControlJoueur joueurActif = controlJeu.getJoueur(tourJoueur % 2);
 			Joueur j = joueurActif.getJoueur();
@@ -176,6 +180,10 @@ public class BoundaryJeu {
 			// Vérifier si la partie est terminée
 			finPartie = controlJeu.verifierFinPartie();
 			
+			if (!finPartie) {
+				finPartie = controlJeu.estNbToursMaxAtteint(nbTour, nbToursMax);
+			}
+			
 			
 			// Défausser les cartes du plateau à la fin du tour
 			controlJeu.defausserCartesPlateau();
@@ -195,6 +203,9 @@ public class BoundaryJeu {
 		
 		// Afficher le résultat final
 		if (finPartie) {
+			if (controlJeu.estNbToursMaxAtteint(nbTour, nbToursMax)) {
+				System.out.println("\n\n\n== Nombre de tours maximum (" + nbToursMax + ") atteint ==");
+			}
 			afficherResultatFinal();
 		} else {
 			System.out.println("\n=== Partie interrompue ===");

--- a/src/controllers/ControlJeu.java
+++ b/src/controllers/ControlJeu.java
@@ -300,4 +300,8 @@ public class ControlJeu {
     		reinitialiserPioche();
     	}
     }
+    
+    public boolean estNbToursMaxAtteint(int nbToursJoues, int nbToursMax) {
+    	return nbToursJoues >= nbToursMax;
+    }
 }

--- a/src/controllers/ControlJeu.java
+++ b/src/controllers/ControlJeu.java
@@ -127,8 +127,7 @@ public class ControlJeu {
             }
         }
         
-        // Vérifier si la pioche est vide
-        return controlPioche.estVide();
+        return false;
     }
     
     /**
@@ -286,5 +285,19 @@ public class ControlJeu {
             return controlJoueurs[joueurActif].defausserCarte(indexCarte);
         }
         return false;
+    }
+    
+    public boolean estPiocheVide() {
+    	return controlPioche.estVide();
+    }
+    
+    public void reinitialiserPioche() {
+    	controlPioche.initialiserPioche();
+    }
+    
+    public void verifierPiocheNonVide() {
+    	if (estPiocheVide()) {
+    		reinitialiserPioche();
+    	}
     }
 }


### PR DESCRIPTION
La partie se terminait au bout de 6 tours (3 par joueur) car la pioche se vidait trop vite et la partie se terminait si la pioche était vide.
Maintenant si la pioche est vide elle se réinitialise, cela va faire des doublons de carte mais sinon on a trop peu de cartes uniques pour pouvoir jouer au jeu sans cette solution.
Note: Possible de faire en sorte de ne pas avoir de doublons dans la main du joueur.
Cependant, pour pas qu'une partie puisse durer éternellement, on fixe maintenant le nombre de tours maximum à 20 (10 par joueur) et on vérifie si on les a atteints à chaque fin de tour.